### PR TITLE
Fix GitHub Pages asset paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+dist
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "/daily-strength-coach/",
+});


### PR DESCRIPTION
## Summary
- load the app entry module using a relative path so GitHub Pages can find it
- add a Vite base path configuration for the daily-strength-coach project
- ignore build and dependency artifacts in version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d46e4eb174832f9be6626c1dcee3fd