### PR TITLE
Configure Vercel output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "buildCommand": "npm run build",
+  "outputDirectory": "docs"
+}


### PR DESCRIPTION
## Summary
- configure Vercel to use the `docs` directory produced by Vite builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d473cc06d8832f87f2709418ea053f